### PR TITLE
Parametrize the version to build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:latest
 
+ARG VERSION
+ENV VERSION=$VERSION
+
 RUN apt-get update
 RUN apt-get install -y curl \
     gnupg

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,17 +1,17 @@
 .PHONY: build run stop check help
 .DEFAULT_GOAL := help
 
-build: ## Build bitcoin image
-	docker build -t boris/bitcoin:22.0 -f Dockerfile .
+build: ## Build bitcoin image. The version is passed through the VERSION variable
+	docker build -t boris/bitcoin:$(VERSION) -f Dockerfile .
 
 run: ## Run the container exposing ports tcp:9332 and tcp:9333
-	docker run --name bitcoin-22-0 -d -p 9332:9332 -p 9333:9333 boris/bitcoin:22.0
+	docker run --name bitcoin-$(VERSION) -d -p 9332:9332 -p 9333:9333 boris/bitcoin:22.0
 
 stop: ## Stop the docker container
-	docker stop bitcoin-22-0
+	docker stop bitcoin-$(VERSION)
 
 check: ## Run a security check using grype
-	grype boris/bitcoin:22.0
+	grype boris/bitcoin:$(VERSION)
 
 help: ## Print this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,8 +1,10 @@
 .PHONY: build run stop check help
 .DEFAULT_GOAL := help
 
+export VERSION := $(VERSION)
+
 build: ## Build bitcoin image. The version is passed through the VERSION variable
-	docker build -t boris/bitcoin:$(VERSION) -f Dockerfile .
+	docker build --build-arg VERSION=$(VERSION) -t boris/bitcoin:$(VERSION) -f Dockerfile .
 
 run: ## Run the container exposing ports tcp:9332 and tcp:9333
 	docker run --name bitcoin-$(VERSION) -d -p 9332:9332 -p 9333:9333 boris/bitcoin:22.0

--- a/docker/files/install.sh
+++ b/docker/files/install.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-VERSION=22.0
+if [[ -z "${VERSION}" ]]; then
+    echo "VERSION is not set"
+    exit 1
+else
+    VERSION=${VERSION}
+fi
 ARCH="x86_64"
 
 echo "Installing Bitcoind $VERSION"


### PR DESCRIPTION
In this PR I'm setting a variable to define the version of Bitcoin we'll build. If the version is not defined, it will fail.

For the next iteration:
- We could query the latest version from [here](https://github.com/bitcoin/bitcoin/releases) and just build the latest, and flashing a message saying that it will build latest because no version was defined.